### PR TITLE
typo fix: pubic -> public

### DIFF
--- a/file-system/partitions/pretty.md
+++ b/file-system/partitions/pretty.md
@@ -1,5 +1,5 @@
 ---
-description: A reduction cache of the pubic tree for better links
+description: A reduction cache of the public tree for better links
 ---
 
 # Pretty

--- a/file-system/sections/pretty.md
+++ b/file-system/sections/pretty.md
@@ -1,5 +1,5 @@
 ---
-description: A reduction cache of the pubic tree for better links
+description: A reduction cache of the public tree for better links
 ---
 
 # Pretty


### PR DESCRIPTION
Small change to fix a typo in two files.

This typo is visible on the rendered web version:

- https://whitepaper.fission.codes/file-system/partitions/pretty
